### PR TITLE
Fix LGT_SCR.cpp "iteration 27 invokes undefined behavior" compilation…

### DIFF
--- a/Marlin/LGT_SCR.cpp
+++ b/Marlin/LGT_SCR.cpp
@@ -396,7 +396,7 @@ void LGT_SCR::LGT_MAC_Send_Filename(uint16_t Addr, uint16_t Serial_Num)
 	data_storage[4] = (Addr & 0xFF00) >> 8;
 	data_storage[5] = Addr;
 	card.getfilename(Serial_Num);
-	for (int i = 0; i < 31; i++)
+	for (int i = 0; i < 27; i++)
 	{
 		data_storage[6 + i] = card.longFilename[i];
 	}


### PR DESCRIPTION
When compiling with Arduino 1.8.9, I get the following warning :

sketch\LGT_SCR.cpp:401:44: warning: iteration 27 invokes undefined behavior [-Waggressive-loop-optimizations]
data_storage[6 + i] = card.longFilename[i];
                                                                ^

Indeed, when looking at it, longFilename is defined here : https://github.com/LONGER3D/Marlin1.1.9_LGT0.3.x_Alfawise_Ux0Pro/blob/master/Marlin/cardreader.h#L122, with a size of 27 : https://github.com/LONGER3D/Marlin1.1.9_LGT0.3.x_Alfawise_Ux0Pro/blob/master/Marlin/SdFatConfig.h#L114